### PR TITLE
Remove misleading `nest_asyncio` reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Clone or download [this sample's repository](https://github.com/Azure-Samples/fa
 
 The code in the sample folder has already been updated to support use of the FastAPI. Let's walk through the changed files.
 
-The `requirements.txt` file has an additional dependency of the `fastapi` and `nest_asyncio` modules:
+The `requirements.txt` file has an additional dependency of the `fastapi` module:
 
 ```
 azure-functions


### PR DESCRIPTION
## Purpose
`nest_asyncio` was already deleted from the `requirements.txt` files before.